### PR TITLE
Automate any future node updates

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -24,7 +24,7 @@ jobs:
         uses: withastro/action@v3
         with:
           path: . # The root location of your Astro project inside the repository. (optional)
-          node-version: 23 # The specific version of Node that should be used to build your site. Defaults to 20. (optional)
+          node-version: 'latest' # The specific version of Node that should be used to build your site. Defaults to 20. (optional)
           package-manager: npm@latest # The Node package manager that should be used to install dependencies and build your site. Automatically detected based on your lockfile. (optional)
 
   deploy:

--- a/.github/workflows/npm_checks.yml
+++ b/.github/workflows/npm_checks.yml
@@ -9,7 +9,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 23
+          node-version: 'latest'
       - run: npm ci
       - run: npm run lint
       - run: npm run build
@@ -20,6 +20,6 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 23
+          node-version: 'latest'
       - run: npm ci
       - run: npm audit --audit-level=high


### PR DESCRIPTION
Unpins node version 23 in the npm build checks and the deploy checks, and so we just go ahead and use the latest node version

- Will throw an error if the latest version of node causes any downstream errors
